### PR TITLE
Apagar uma nota

### DIFF
--- a/resources/views/delete_note.blade.php
+++ b/resources/views/delete_note.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.main_layout')
+@section('content')
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col">
+
+                @include('top_bar')
+                <div class="col card p-5 text-center">
+                    <span class="display-3 mb-5"><i
+                            class="fa-solid fa-triangle-exclamation text-warning opacity-50"></i></span>
+                    <h4 class="text-info mb-3">{{ $note->title }}</h4>
+                    <p class="text-secondary">Are you sure you want to delete this note?</p>
+                    <div class="mt-3">
+                        <a href="{{ route('home') }}" class="btn btn-primary px-5 m-2"><i
+                                class="fa-solid fa-xmark me-2"></i>No</a>
+                        <a href="{{ route('deleteConfirm', ['id' => Crypt::encrypt($note->id)])}}" class="btn btn-danger px-5 m-2"><i class="fa-solid fa-trash me-2"></i>Yes</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ Route::middleware([CheckIsLogged::class])->group(function () {
 
     // Deletar nota
     Route::get('/deleteNote/{id}', [MainController::class, 'deleteNote'])->name('delete');
+    Route::get('deleteNoteConfirm/"{id}', [MainController::class, 'deleteNoteConfirm'])->name('deleteConfirm');
 
     // Efetuar logout
     Route::get('/logout', [AuthController::class, 'logout'])->name('logout');


### PR DESCRIPTION
Foi inserida a instrução ->whereNull('deleted_at') para que o sistema selecione             somente as notas que não tiverem uma data de deleção preenchida. Essa alteração foi feita após inserir no método "deleteNoteConfirm" a técnica para             soft delete (incluindo a data de deleção no banco de dados).
Equivalência: SELECT * FROM notes WHERE deleted_at IS NULL;